### PR TITLE
Optional semicolon in html entities regex

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -1095,7 +1095,7 @@ function escape(html, encode) {
 
 function unescape(html) {
 	// explicitly match decimal, hex, and named HTML entities 
-  return html.replace(/&(#(?:\d+)|(?:#x[0-9A-Fa-f]+)|(\w+))/g, function(_, n) {
+  return html.replace(/&(#(?:\d+)|(?:#x[0-9A-Fa-f]+)|(?:\w+));?/g, function(_, n) {
     n = n.toLowerCase();
     if (n === 'colon') return ':';
     if (n.charAt(0) === '#') {


### PR DESCRIPTION
I added an optional semicolon in the regex of the `unescape()` function and I made non-capturing group out of (\w+) that was not used in the function (only the entire surrounding group is used as a whole). The semicolon is outside of the capturing group so the input to the function is the same as before.

See [this comment](https://github.com/chjj/marked/pull/592/files/2cff859#r70888592) and PR: chjj/marked#592
